### PR TITLE
チーム削除機能の完成

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -28,6 +28,8 @@ class TeamsController < ApplicationController
 
   def destroy
     @team = Team.find(params[:id])
+    @team.tasks.destroy_all
+    @team.team_users.destroy_all
     @team.destroy
     redirect_to root_path, notice: "チームが削除されました"
   end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,7 +1,7 @@
 class Team < ApplicationRecord
-  has_many :team_users
+  has_many :team_users, dependent: :destroy
   has_many :users, through: :team_users
-  has_many :tasks
+  has_many :tasks, dependent: :destroy
 
   def display_name
     if name.length > 5


### PR DESCRIPTION
## 概要
- チーム削除機能の完成

## 対応内容
- `localhost:3000/teams/:id/tasks`のタスク一覧画面のトラッシュボックスアイコンを押下時に表示されているチームを削除する。

## 動作確認方法
### チーム削除
1. コマンド`bin/dev`で起動後、作成済みユーザーでログインを行う。
2. `localhost:3000/teams/:id/tasks`にで任意のチームのタスク一覧画面にアクセス。
4. チーム名右のトラッシュボックスアイコンを押下。
5. 該当チームが削除されホーム画面にリダイレクトされる。

## レビューポイント
- 以前のメンタリングでおっしゃっていたdependent: :destoryを導入したため、使い方が正しいか見ていただけると幸いです。
