### PR TITLE
チーム追加および更新時にエラーメッセージを表示するように修正。

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -3,6 +3,8 @@ class Team < ApplicationRecord
   has_many :users, through: :team_users
   has_many :tasks, dependent: :destroy
 
+  validates :name, presence: true, length: { minimum: 1, maximum: 50 }
+
   def display_name
     if name.length > 5
       name[0..4] + "..."

--- a/app/views/teams/edit.html.erb
+++ b/app/views/teams/edit.html.erb
@@ -3,6 +3,15 @@
     <h2 class="team-edit-form-title">
       チーム更新
     </h2>
+    <% if @team.errors.any? %>
+    <div class="error-messages">
+      <ul>
+        <% @team.errors.full_messages.each do |message| %>
+        <li class="error-message"><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+    <% end %>
     <%= form_with model: @team, class: "team-edit-form", local: true do |f| %>
     <div class="team-edit-label-container">
       <%= f.label :name, "チーム名", class: "team-edit-form-label" %>

--- a/app/views/teams/new.html.erb
+++ b/app/views/teams/new.html.erb
@@ -3,6 +3,15 @@
     <h2 class="team-edit-form-title">
       チーム追加
     </h2>
+    <% if @team.errors.any? %>
+    <div class="error-messages">
+      <ul>
+        <% @team.errors.full_messages.each do |message| %>
+        <li class="error-message"><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+    <% end %>
     <%= form_with model: @team, class: "team-edit-form", local: true do |f| %>
     <div class="team-edit-label-container">
       <%= f.label :name, "チーム名", class: "team-edit-form-label" %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -29,12 +29,17 @@ ja:
             task:
                 name: タイトル
                 status: ステータス
+            team:
+                name: チーム名
         errors:
             messages:
                 record_invalid: '入力内容に誤りがあります: %{errors}'
                 restrict_dependent_destroy:
                     has_one: '%{record}が存在しているので削除できません'
                     has_many: '%{record}が存在しているので削除できません'
+                blank: を入力してください
+                too_short: は%{count}文字以上で入力してください
+                too_long: は%{count}文字以下で入力してください
             models:
                 task:
                     attributes:


### PR DESCRIPTION
## 概要
- チーム追加および更新時にエラーメッセージを表示させる。

## 対応内容
- チーム追加および更新時、入力内容に不備はあった場合エラーメッセージを表示するように修正。
- noticeをヘッダー下に表示するように修正。それに伴ってScssも一部修正。

## 動作確認方法
### チーム追加or更新
- チーム追加か更新画面のパスにアクセスし、不正な値（空白のみ、51文字以上）を入力する。
- エラーメッセージが表示され、再度入力を促される。

## 画面のスクリーンショット
<img width="1916" alt="スクリーンショット 2025-05-13 0 47 07" src="https://github.com/user-attachments/assets/1a96caf7-6a4c-4ce2-bc66-e3b1a23b9ea0" />
